### PR TITLE
Redirect to landing page when user doesn't have an event

### DIFF
--- a/src/contexts/EventContext.jsx
+++ b/src/contexts/EventContext.jsx
@@ -10,7 +10,7 @@ export const EventProvider = ({ children }) => {
     const { keycloak } = useKeycloak();
     
     const [eventInfo, setEventInfo] = useState(null);
-    const [isLoading, setIsLoading] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
 
     // Get event information

--- a/src/pages/Instantiate.jsx
+++ b/src/pages/Instantiate.jsx
@@ -1,13 +1,23 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import {Link, useNavigate} from 'react-router-dom';
 import { FaPalette, FaCogs, FaCalendarAlt, FaPuzzlePiece, FaUsers, FaBars, FaArrowRight, FaFile } from 'react-icons/fa';
 import { useEvent } from '../contexts/EventContext';
 import { useTranslation } from 'react-i18next';
 
 export default function Instantiate() {
     const { t } = useTranslation();
-    const { eventInfo, isLoading } = useEvent();
+    const { eventInfo ,isLoading } = useEvent();
+    const navigate = useNavigate();
 
+    console.log("Event Info:", eventInfo);
+
+    useEffect(() => {
+        console.log("isLoassidkelm:", isLoading)
+        console.log("Event Info2123:", eventInfo);
+        if (!isLoading && eventInfo === null) {
+            navigate('/setup');
+        }
+    }, [isLoading, eventInfo, navigate]);
     
 
     // Add section cards with direct homepage links


### PR DESCRIPTION
This pull request includes changes to improve the user experience by adjusting the initial loading state and adding navigation logic to handle missing event information. The most important changes include setting the default `isLoading` state to `true` in the `EventProvider` and adding a `useEffect` hook in the `Instantiate` page to redirect users when no event information is available.

### Improvements to loading state and navigation:

* [`src/contexts/EventContext.jsx`](diffhunk://#diff-df9a2325b458c3b2c2da12e3666c3ebe21214e58adf73790a7767c9f5563f13aL13-R13): Changed the initial state of `isLoading` from `false` to `true` in the `EventProvider` to better reflect the loading state during the initial fetch of event information.

* `src/pages/Instantiate.jsx`: 
  - Added `useNavigate` from `react-router-dom` to enable programmatic navigation.
  - Introduced a `useEffect` hook to monitor `isLoading` and `eventInfo`. If loading is complete and `eventInfo` is `null`, the user is redirected to the `/setup` page. This ensures a smoother user experience when no event data is available.

