### PR TITLE
remove activity form fields

### DIFF
--- a/src/components/activities/NewSessionModal.jsx
+++ b/src/components/activities/NewSessionModal.jsx
@@ -47,11 +47,8 @@ export function NewSessionModal({ isOpen, onClose, onSubmit }) {
     duration: 30,
     type_id: "",
     topic: "",
-    speaker: "",
     facilitator: "",
     image: null,
-    requires_registration: false,
-    max_participants: ""
   };
 
   const { 
@@ -135,12 +132,6 @@ export function NewSessionModal({ isOpen, onClose, onSubmit }) {
   };
 
   const formatDataForSubmission = () => {
-    let maxParticipants = 0;
-    if (values.requires_registration && values.max_participants) {
-      const parsedValue = parseInt(values.max_participants, 10);
-      maxParticipants = !isNaN(parsedValue) ? parsedValue : 0;
-    }
-
     return {
       name: values.name,
       description: values.description,
@@ -148,10 +139,7 @@ export function NewSessionModal({ isOpen, onClose, onSubmit }) {
       duration: parseInt(values.duration, 10),
       type_id: typeof values.type_id === 'string' ? parseInt(values.type_id, 10) : values.type_id,
       topic: values.topic || "",
-      speaker: values.speaker || "",
       facilitator: values.facilitator || "",
-      requires_registration: values.requires_registration || false,
-      max_participants: maxParticipants,
       ...(imagePreview && { image: values.image })
     };
   };
@@ -426,50 +414,7 @@ export function NewSessionModal({ isOpen, onClose, onSubmit }) {
               </FormField>
             </div>
             
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <FormField label="Registration" id="requires_registration">
-                <div className="flex items-center">
-                  <input
-                    type="checkbox"
-                    id="requires_registration"
-                    name="requires_registration"
-                    checked={values.requires_registration}
-                    onChange={handleChangeWithStop}
-                    className="checkbox checkbox-primary mr-2"
-                  />
-                  <label htmlFor="requires_registration" className="block font-medium">
-                    Require registration
-                  </label>
-                </div>
-              </FormField>
-              
-              <FormField label="Maximum participants" id="max_participants">
-                <input
-                  type="number"
-                  id="max_participants"
-                  name="max_participants"
-                  value={values.max_participants === 0 ? "" : values.max_participants}
-                  onChange={handleChangeWithStop}
-                  min="0"
-                  disabled={!values.requires_registration}
-                  className="input input-bordered w-full"
-                  placeholder="Enter the maximum number of participants"
-                />
-              </FormField>
-            </div>
-            
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <FormField label="Activity Owner" id="activity_owner">
-                <input
-                  type="text"
-                  id="activity_owner"
-                  name="activity_owner"
-                  value={values.speaker}
-                  onChange={handleChangeWithStop}
-                  placeholder="Enter the activity owner name"
-                  className="input input-bordered w-full"
-                />
-              </FormField>
+            <div className="grid grid-cols-1 gap-4">
               <FormField label="Topic" id="topic">
                 <input
                     type="text"


### PR DESCRIPTION
# Pull Request Title

## Description
<!--- Describe your changes in detail. Explain the purpose of this PR and the problem it solves. Include any relevant context or screenshots. -->

This pull request simplifies the `NewSessionModal` component by removing unused fields and associated logic, streamlining the data model and UI. The changes focus on eliminating unnecessary complexity and improving maintainability.

### Removal of unused fields and logic:

* Removed the `speaker`, `requires_registration`, and `max_participants` fields from the initial state and submission logic, as they are no longer required. (`src/components/activities/NewSessionModal.jsx`, [[1]](diffhunk://#diff-aae3c94a176d36a0355a926b5354c945798357d4a8595952580d68e33900bab1L50-L54) [[2]](diffhunk://#diff-aae3c94a176d36a0355a926b5354c945798357d4a8595952580d68e33900bab1L138-L154)
* Deleted the logic for handling `requires_registration` and `max_participants`, including parsing and validation, from the `formatDataForSubmission` function. (`src/components/activities/NewSessionModal.jsx`, [src/components/activities/NewSessionModal.jsxL138-L154](diffhunk://#diff-aae3c94a176d36a0355a926b5354c945798357d4a8595952580d68e33900bab1L138-L154))

### UI simplification:

* Removed the UI elements for `requires_registration`, `max_participants`, and `speaker` fields, including their form fields and labels, to align with the updated data model. (`src/components/activities/NewSessionModal.jsx`, [src/components/activities/NewSessionModal.jsxL429-R417](diffhunk://#diff-aae3c94a176d36a0355a926b5354c945798357d4a8595952580d68e33900bab1L429-R417))

## Type of Change
<!--- Mark with an `x` the type of change your PR introduces. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have written tests for my changes or updated existing ones.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation where needed.


## How Has This Been Tested?
<!--- Describe the testing you've done to verify your changes. Include details about testing environment setup and edge cases covered. -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify)
