### PR TITLE
remove dashboard iframe

### DIFF
--- a/src/pages/Instantiate.jsx
+++ b/src/pages/Instantiate.jsx
@@ -65,16 +65,15 @@ export default function Instantiate() {
                     )}
                 </div>
 
-                {/* App preview phone mockup */}
-                <div className="mb-10 flex flex-col md:flex-row gap-6">
-                    <div className="hidden sm:block md:w-1/2 flex justify-center">
+                <div className="mb-10 gap-6">
+                    {/* <div className="hidden sm:block md:w-1/2 flex justify-center">
                         <iframe
-                            src="http://localhost:5175/app/"
+                            src=""
                             className="w-2/3 h-[750px] border-0 rounded-lg shadow-lg"
                             title="Mobile App Preview"
                         ></iframe>
-                    </div>
-                    <div className="w-full md:w-1/2 flex justify-start flex-col gap-6">
+                    </div> */}
+                    <div className="w-full flex justify-start flex-col gap-6">
                         {sectionCards.map(card => (
                             <Link
                                 key={card.id}


### PR DESCRIPTION
This pull request modifies the `Instantiate` component in `src/pages/Instantiate.jsx` to simplify the layout and temporarily disable the app preview phone mockup.

### Layout simplification:
* Removed the `div` containing the app preview phone mockup and commented out the associated `iframe` element. This change simplifies the layout and removes the hardcoded `src` attribute for the iframe, which previously pointed to a local development server.

### Temporary removal of app preview:
* The app preview functionality has been disabled by commenting out the relevant code. This may be a temporary measure, possibly for debugging or to address issues with the preview.