### PR TITLE
Hotfix/menu creation on add page

### DIFF
--- a/src/pages/PagesList.jsx
+++ b/src/pages/PagesList.jsx
@@ -106,7 +106,7 @@ export function PagesList() {
                 };
 
                 await axiosInstance.post(
-                    `${baseUrl}/ui/menu/option`,
+                    `${baseUrl}/ui/menu/option/`,
                     menuOption
                 );
             } else {

--- a/src/pages/page_editor/CreatePage.jsx
+++ b/src/pages/page_editor/CreatePage.jsx
@@ -104,7 +104,7 @@ export function CreatePage() {
 
             const axiosInstance = axiosWithAuth(keycloak);
             await axiosInstance.post(
-                `${baseUrl}/ui/menu/option`,
+                `${baseUrl}/ui/menu/option/`,
                 menuOption
             );
 


### PR DESCRIPTION
This pull request refactors the `ManifestContext` to optimize its performance, updates the `IconsEditor` to improve favicon handling, and includes a minor fix in the `PagesList`. Below are the most important changes grouped by theme:

### Performance Optimization in `ManifestContext`:

* Introduced `useMemo` in `ManifestProvider` to memoize the context value, ensuring it only recalculates when the `keycloak` dependency changes. This avoids unnecessary re-renders and improves performance. [[1]](diffhunk://#diff-c22466450810e1d317ba9b41f39317b5b25444e66325434a3739cef798ccdb00L1-R1) [[2]](diffhunk://#diff-c22466450810e1d317ba9b41f39317b5b25444e66325434a3739cef798ccdb00R12-R13) [[3]](diffhunk://#diff-c22466450810e1d317ba9b41f39317b5b25444e66325434a3739cef798ccdb00L39-R51)

### Enhancements to Favicon Handling in `IconsEditor`:

* Updated the favicon preview logic to handle relative paths using `baseUrl` for consistency.
* Allowed PNG files as valid favicon types and added stricter dimension validation for standard favicon sizes (16×16, 32×32, 48×48). This ensures better compatibility with favicon standards.
* Removed unnecessary dependencies from the `useEffect` dependency array to prevent redundant data fetching.

### Minor Fix in `PagesList`:

* Fixed the URL for posting menu options by ensuring a trailing slash is included, aligning with API endpoint requirements.