### PR TITLE
change delete url

### DIFF
--- a/src/pages/plugins/SpeakerManagement.jsx
+++ b/src/pages/plugins/SpeakerManagement.jsx
@@ -308,7 +308,7 @@ const SpeakerManagement = () => {
   const deleteSpeaker = async (id) => {
     setLoading(true);
     try {
-      await axiosWithAuth(keycloak).delete(`${API_ENDPOINTS.SPEAKERS}/${id}/`);
+      await axiosWithAuth(keycloak).delete(`${API_ENDPOINTS.SPEAKERS}/${id}`);
       return { success: true };
     } catch (err) {
       const errorMessage = err.response?.data?.detail || 'Failed to delete speaker';


### PR DESCRIPTION
This pull request includes a minor fix to the `SpeakerManagement` component in `src/pages/plugins/SpeakerManagement.jsx`. The change removes an unnecessary trailing slash from the API endpoint used in the `deleteSpeaker` function.

* [`src/pages/plugins/SpeakerManagement.jsx`](diffhunk://#diff-33a66dc431aeedb8bbaa60a1098228b6c68688f8baebba24a779ff2e8273ed33L311-R311): Updated the `deleteSpeaker` function to remove the trailing slash from the API endpoint URL for consistency and to prevent potential issues with endpoint routing.