### PR TITLE
Hotfix/fix delete sponsors

### DIFF
--- a/src/pages/plugins/Sponsors.jsx
+++ b/src/pages/plugins/Sponsors.jsx
@@ -34,6 +34,11 @@ const useSponsorForm = (initialLevelId = 0) => {
       ...prev,
       [name]: value
     }));
+
+    // Update logo preview when logo_url changes
+    if (name === 'logo_url') {
+      setLogoPreview(value);
+    }
   };
 
   const handleLogoFileChange = (e) => {
@@ -85,7 +90,7 @@ const useSponsorForm = (initialLevelId = 0) => {
   const setFormData = (data) => {
     setSponsorForm({
       name: data.name,
-      logo_url: data.logo_url || '',
+      logo_url: data.logo_url && !data.logo_url.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i) ? data.logo_url : '',
       website_url: data.website_url || '',
       description: data.description || '',
       level_id: data.level_id
@@ -94,8 +99,10 @@ const useSponsorForm = (initialLevelId = 0) => {
       // If it's a UUID (media), use getMediaUrl
       if (data.logo_url.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)) {
         setLogoPreview(getMediaUrl(data.logo_url));
+        setLogoInputType('file'); // Set to file input type when it's a UUID
       } else {
         setLogoPreview(data.logo_url);
+        setLogoInputType('url'); // Set to URL input type when it's a regular URL
       }
     }
   };

--- a/src/pages/plugins/Sponsors.jsx
+++ b/src/pages/plugins/Sponsors.jsx
@@ -394,6 +394,44 @@ export function Sponsors() {
     }
   };
 
+  // Delete sponsor
+  const handleDeleteSponsor = async (sponsorId) => {
+    if (!window.confirm("Are you sure you want to delete this sponsor?")) {
+      return;
+    }
+
+    setIsLoading(prev => ({ ...prev, sponsors: true }));
+    try {
+      await axiosWithAuth(keycloak).delete(`${API_ENDPOINTS.SPONSORS}/${sponsorId}`);
+      setSponsors(prevSponsors => prevSponsors.filter(sponsor => sponsor.id !== sponsorId));
+      showNotification("Sponsor deleted successfully", "success");
+    } catch (err) {
+      console.error("Error deleting sponsor:", err);
+      showNotification("Failed to delete sponsor", "error");
+    } finally {
+      setIsLoading(prev => ({ ...prev, sponsors: false }));
+    }
+  };
+
+  // Delete level
+  const handleDeleteLevel = async (levelId) => {
+    if (!window.confirm("Are you sure you want to delete this level? This action cannot be undone.")) {
+      return;
+    }
+
+    setIsLoading(prev => ({ ...prev, levels: true }));
+    try {
+      await axiosWithAuth(keycloak).delete(`${API_ENDPOINTS.LEVELS}/${levelId}`);
+      setLevels(prevLevels => prevLevels.filter(level => level.id !== levelId));
+      showNotification("Level deleted successfully", "success");
+    } catch (err) {
+      console.error("Error deleting level:", err);
+      showNotification("Failed to delete level", "error");
+    } finally {
+      setIsLoading(prev => ({ ...prev, levels: false }));
+    }
+  };
+
   return (
     <div className="w-full min-h-screen p-4 sm:p-6 lg:p-8">
       <h1 className="text-3xl font-bold my-8">Sponsors Management</h1>

--- a/src/pages/plugins/Sponsors.jsx
+++ b/src/pages/plugins/Sponsors.jsx
@@ -368,8 +368,15 @@ export function Sponsors() {
     try {
       const response = await axiosWithAuth(keycloak).put(
         `${API_ENDPOINTS.SPONSORS}/${selectedSponsor.id}`, 
-        sponsorForm
+        {
+          ...sponsorForm,
+          logo_url: logoInputType === 'file' ? '' : sponsorForm.logo_url
+        }
       );
+
+      if (logoInputType === 'file' && logoFile && response.data.logo_url) {
+        await uploadMedia(response.data.logo_url, logoFile);
+      }
 
       const updatedSponsor = {
         ...response.data,

--- a/src/pages/plugins/Sponsors.jsx
+++ b/src/pages/plugins/Sponsors.jsx
@@ -26,6 +26,7 @@ const useSponsorForm = (initialLevelId = 0) => {
   const [logoPreview, setLogoPreview] = useState(null);
   const logoMediaRef = useRef(null);
   const { showNotification } = useNotification();
+  const { getMediaUrl } = useMedia();
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -90,7 +91,12 @@ const useSponsorForm = (initialLevelId = 0) => {
       level_id: data.level_id
     });
     if (data.logo_url) {
-      setLogoPreview(data.logo_url);
+      // If it's a UUID (media), use getMediaUrl
+      if (data.logo_url.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)) {
+        setLogoPreview(getMediaUrl(data.logo_url));
+      } else {
+        setLogoPreview(data.logo_url);
+      }
     }
   };
 

--- a/src/pages/plugins/Sponsors.jsx
+++ b/src/pages/plugins/Sponsors.jsx
@@ -314,6 +314,7 @@ export function Sponsors() {
           sponsor.description?.toLowerCase().includes(query) ||
           sponsor.website_url?.toLowerCase().includes(query)
         )
+        .sort((a, b) => a.name.localeCompare(b.name)) // Sort sponsors by name
     }));
   }, [sponsors, levels, searchQuery]);
 


### PR DESCRIPTION
This pull request enhances the `Sponsors` management functionality in the `src/pages/plugins/Sponsors.jsx` file. Key improvements include better handling of sponsor logo URLs, support for uploading media files, and the addition of delete functionality for sponsors and levels.

### Enhancements to logo handling:
* Added `getMediaUrl` utility to handle media URLs and updated `logo_url` logic to differentiate between UUIDs (media files) and regular URLs. This ensures proper preview rendering and input type management. [[1]](diffhunk://#diff-4006cc1e53db68b9b84997f57a21a005fac2c5145fdc83857bc34b9372e848bcR29-R41) [[2]](diffhunk://#diff-4006cc1e53db68b9b84997f57a21a005fac2c5145fdc83857bc34b9372e848bcL87-R106)
* Modified the sponsor update logic to handle media file uploads when `logo_url` is a UUID, ensuring seamless integration with the backend.

### New delete functionality:
* Added `handleDeleteSponsor` function to allow deletion of sponsors with confirmation prompts and error handling.
* Added `handleDeleteLevel` function to enable deletion of sponsor levels with confirmation prompts and error handling.