### PR TITLE
adapt forms and cards to optional type

### DIFF
--- a/src/components/activities/CreateActivityModal.jsx
+++ b/src/components/activities/CreateActivityModal.jsx
@@ -39,7 +39,7 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
     handleChange(e);
   };
 
-  const { activityTypes, loading, createActivityType } = useActivities();
+  const { activityTypes, loading } = useActivities();
   const { showNotification } = useNotification();
   
   const initialValues = {
@@ -64,9 +64,6 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
   
   const [imagePreview, setImagePreview] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isAddingTypeInline, setIsAddingTypeInline] = useState(false);
-  const [newTypeName, setNewTypeName] = useState("");
-  const [isAddingType, setIsAddingType] = useState(false);
   const fileInputRef = useRef(null);
 
   useEffect(() => {
@@ -80,7 +77,6 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
     
     if (!values.name.trim()) newErrors.name = "Name is required";
     if (!values.description.trim()) newErrors.description = "Description is required";
-    if (!values.type_id) newErrors.type_id = "Type is required";
 
     if (values.date) {
       validateDate(values.date, newErrors);
@@ -134,7 +130,7 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
       description: values.description,
       date: values.date ? localDatetimeLocalToUTC(values.date) : undefined,
       duration: parseInt(values.duration, 10),
-      type_id: typeof values.type_id === 'string' ? parseInt(values.type_id, 10) : values.type_id,
+      type_id: values.type_id ? (typeof values.type_id === 'string' ? parseInt(values.type_id, 10) : values.type_id) : null,
       topic: values.topic || "",
       ...(imagePreview && { image: values.image })
     };
@@ -170,33 +166,7 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
     onClose();
   };
 
-  const handleSaveInlineType = async () => {
-    if (!newTypeName.trim()) return;
-    
-    setIsAddingType(true);
-    
-    try {
-      const typeData = { type: newTypeName.trim() };
-      const newType = await createActivityType(typeData);
-      
-      setFieldValue('type_id', newType.id);
-      setNewTypeName("");
-      setIsAddingTypeInline(false);
-      
-      showNotification(`Activity type "${newTypeName}" was created successfully`, "success");
-    } catch (error) {
-      console.error("Error creating activity type:", error);
-      showNotification("Failed to create activity type", "error");
-    } finally {
-      setIsAddingType(false);
-    }
-  };
-
   const renderTypeSelector = () => {
-    if (isAddingTypeInline) {
-      return renderTypeCreator();
-    }
-    
     return (
       <div className="">
         <select
@@ -213,41 +183,6 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
             </option>
           ))}
         </select>
-      </div>
-    );
-  };
-
-  const renderTypeCreator = () => {
-    return (
-      <div className="flex items-center border rounded-lg overflow-hidden">
-        <input
-          type="text"
-          placeholder="Enter new type name"
-          value={newTypeName}
-          onChange={(e) => setNewTypeName(e.target.value)}
-          className="input input-sm flex-grow border-none focus:outline-none"
-        />
-        {isAddingType ? (
-          <span className="loading loading-spinner loading-sm mx-2"></span>
-        ) : (
-          <div className="flex border-l">
-            <button
-              type="button"
-              className="btn btn-sm btn-ghost px-2"
-              onClick={() => setIsAddingTypeInline(false)}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm btn-primary px-2"
-              onClick={handleSaveInlineType}
-              disabled={!newTypeName.trim()}
-            >
-              Save
-            </button>
-          </div>
-        )}
       </div>
     );
   };
@@ -377,7 +312,7 @@ export function CreateActivityModal({ isOpen, onClose, onSubmit }) {
                 className={`textarea textarea-bordered w-full h-24 ${errors.description ? 'textarea-error' : ''}`}
               />
             </FormField>
-            <FormField label="Type" id="type_id" required error={errors.type_id}>
+            <FormField label="Type" id="type_id" error={errors.type_id}>
               <div className={`relative ${errors.type_id ? 'border-error' : 'border-base-300'}`}>
                 {renderTypeSelector()}
               </div>

--- a/src/components/activities/EditActivityModal.jsx
+++ b/src/components/activities/EditActivityModal.jsx
@@ -108,7 +108,6 @@ export function EditActivityModal({ isOpen, onClose, activity }) {
     
     if (!formData.name.trim()) newErrors.name = t('validation.required');
     if (!formData.description.trim()) newErrors.description = t('validation.required');
-    if (!formData.type_id) newErrors.type_id = t('validation.required');
     
     if (formData.date) {
       const activityDate = new Date(formData.date);
@@ -157,7 +156,7 @@ export function EditActivityModal({ isOpen, onClose, activity }) {
     const payload = {
       name: formData.name,
       description: formData.description,
-      type_id: parseInt(formData.type_id, 10),
+      type_id: formData.type_id ? (parseInt(formData.type_id, 10) || null) : null,
       topic: formData.topic || "",
     };
 
@@ -368,8 +367,7 @@ export function EditActivityModal({ isOpen, onClose, activity }) {
           <div>
             <FormField 
               label={t('activities.type')} 
-              id="type_id" 
-              required 
+              id="type_id"  
               error={errors.type_id}
             >
               <select
@@ -378,7 +376,6 @@ export function EditActivityModal({ isOpen, onClose, activity }) {
                 value={formData.type_id}
                 onChange={handleChangeWithStop}
                 className="select select-bordered select-sm w-full"
-                required
               >
                 <option value="">{t('activities.selectType')}</option>
                 {activityTypes.map((type) => (

--- a/src/pages/Activities.jsx
+++ b/src/pages/Activities.jsx
@@ -63,7 +63,7 @@ export default function Activities() {
       activity.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       activity.description?.toLowerCase().includes(searchQuery.toLowerCase());
       
-    const matchesType = !selectedType || activity.type_id.toString() === selectedType;
+    const matchesType = !selectedType || (activity.type_id && activity.type_id.toString() === selectedType);
     
     return matchesSearch && matchesType;
   });


### PR DESCRIPTION
# Pull Request Title

## Description
<!--- Describe your changes in detail. Explain the purpose of this PR and the problem it solves. Include any relevant context or screenshots. -->

This pull request introduces changes to simplify the handling of activity types in modals, refactor the `Activity` component for better modularity, and improve type handling across the codebase. The most important changes include removing inline activity type creation functionality, refactoring the `Activity` component into smaller subcomponents, and ensuring robust handling of `type_id` values.

### Activity Type Handling Improvements:
* Removed inline activity type creation functionality from `CreateActivityModal`, including related state variables, validation, and rendering logic. This simplifies the modal and delegates type creation to a separate workflow. (`[[1]](diffhunk://#diff-48b82545cfc1554f17960131ae35e8c8d4bf8824370363ba5a6a07e2792c6a22L42-R42)`, `[[2]](diffhunk://#diff-48b82545cfc1554f17960131ae35e8c8d4bf8824370363ba5a6a07e2792c6a22L67-L69)`, `[[3]](diffhunk://#diff-48b82545cfc1554f17960131ae35e8c8d4bf8824370363ba5a6a07e2792c6a22L173-L199)`, `[[4]](diffhunk://#diff-48b82545cfc1554f17960131ae35e8c8d4bf8824370363ba5a6a07e2792c6a22L220-L254)`)
* Updated `type_id` handling in `CreateActivityModal` and `EditActivityModal` to ensure null values are correctly handled when no type is selected. (`[[1]](diffhunk://#diff-48b82545cfc1554f17960131ae35e8c8d4bf8824370363ba5a6a07e2792c6a22L137-R133)`, `[[2]](diffhunk://#diff-79290ba9b9d062fee5c174335ca8574a3b1a802315fa1c8dadabb5ccbbaf510fL160-R159)`)

### Component Refactoring:
* Refactored the `Activity` component by extracting `ActivityImage` and `ActionButtons` as separate subcomponents. This improves readability and modularity. (`[[1]](diffhunk://#diff-731dd288852f794477aa6563708e3caf2f2ad48484f8f6601062226efb531481L7-R53)`, `[[2]](diffhunk://#diff-731dd288852f794477aa6563708e3caf2f2ad48484f8f6601062226efb531481L82-R141)`)
* Added `propTypes` and `defaultProps` for the new subcomponents to enforce type safety and default behavior. (`[[1]](diffhunk://#diff-731dd288852f794477aa6563708e3caf2f2ad48484f8f6601062226efb531481L171-R167)`, `[[2]](diffhunk://#diff-731dd288852f794477aa6563708e3caf2f2ad48484f8f6601062226efb531481L181-R177)`)

### UI and Validation Adjustments:
* Removed "required" validation for type selection in modals to allow activities without a type. (`[[1]](diffhunk://#diff-48b82545cfc1554f17960131ae35e8c8d4bf8824370363ba5a6a07e2792c6a22L83)`, `[[2]](diffhunk://#diff-79290ba9b9d062fee5c174335ca8574a3b1a802315fa1c8dadabb5ccbbaf510fL111)`, `[[3]](diffhunk://#diff-79290ba9b9d062fee5c174335ca8574a3b1a802315fa1c8dadabb5ccbbaf510fL372)`, `[[4]](diffhunk://#diff-79290ba9b9d062fee5c174335ca8574a3b1a802315fa1c8dadabb5ccbbaf510fL381)`)
* Adjusted the logic for filtering activities by type in the `Activities` page to account for cases where `type_id` is null. (`[src/pages/Activities.jsxL66-R66](diffhunk://#diff-1e9fb9997bb69d6eac9ac4d0a6a5cf55023f3a745a7cad95f17c70f122e15ee7L66-R66)`)

## Type of Change
<!--- Mark with an `x` the type of change your PR introduces. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have written tests for my changes or updated existing ones.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation where needed.

## How Has This Been Tested?
<!--- Describe the testing you've done to verify your changes. Include details about testing environment setup and edge cases covered. -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please specify)